### PR TITLE
add PinyinTokenFilter to work with Tokenizer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     </parent>
 
     <properties>
-        <elasticsearch.version>0.19.0</elasticsearch.version>
+        <elasticsearch.version>0.19.8</elasticsearch.version>
     </properties>
 
 

--- a/src/main/java/org/elasticsearch/index/analysis/PinyinAnalysisBinderProcessor.java
+++ b/src/main/java/org/elasticsearch/index/analysis/PinyinAnalysisBinderProcessor.java
@@ -36,6 +36,6 @@ public class PinyinAnalysisBinderProcessor extends AnalysisModule.AnalysisBinder
 
     @Override
     public void processTokenFilters(TokenFiltersBindings tokenFiltersBindings) {
-//        tokenFiltersBindings.processTokenFilter("pinyin", PinyinTokenFilterFactory.class);
+        tokenFiltersBindings.processTokenFilter("pinyin", PinyinTokenFilterFactory.class);
     }
 }

--- a/src/main/java/org/elasticsearch/index/analysis/PinyinTokenFilter.java
+++ b/src/main/java/org/elasticsearch/index/analysis/PinyinTokenFilter.java
@@ -1,0 +1,114 @@
+package org.elasticsearch.index.analysis;
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.IOException;
+import java.io.Reader;
+
+import net.sourceforge.pinyin4j.PinyinHelper;
+import net.sourceforge.pinyin4j.format.HanyuPinyinCaseType;
+import net.sourceforge.pinyin4j.format.HanyuPinyinOutputFormat;
+import net.sourceforge.pinyin4j.format.HanyuPinyinToneType;
+import net.sourceforge.pinyin4j.format.HanyuPinyinVCharType;
+import net.sourceforge.pinyin4j.format.exception.BadHanyuPinyinOutputFormatCombination;
+import org.apache.lucene.analysis.TokenFilter;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
+import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
+import org.apache.lucene.util.Version;
+
+/**
+ */
+public class PinyinTokenFilter extends TokenFilter {
+
+    private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
+    private OffsetAttribute offsetAtt = addAttribute(OffsetAttribute.class);
+    private HanyuPinyinOutputFormat format = new HanyuPinyinOutputFormat();
+    private String padding_char;
+    private String first_letter;
+    @Override
+    public final boolean incrementToken() throws IOException {
+        if (!input.incrementToken()) {
+            return false;
+        }
+
+        final char[] buffer = termAtt.buffer();
+        final int bufferLength = termAtt.length();
+        StringBuilder stringBuilder = new StringBuilder();
+        StringBuilder firstLetters = new StringBuilder();
+        for (int i = 0; i < bufferLength; i++) {
+            char c = buffer[i];
+            if (c < 128) {
+                stringBuilder.append(c);
+            } else {
+                try {
+                    String[] strs = PinyinHelper.toHanyuPinyinStringArray(c, format);
+                    if (strs != null) {
+                        //get first result by default
+                        String first_value = strs[0];
+                        //TODO more than one pinyin
+                        stringBuilder.append(first_value);
+                        if (this.padding_char.length() > 0) {
+                            stringBuilder.append(this.padding_char);
+                        }
+                        firstLetters.append(first_value.charAt(0));
+
+                    }
+                } catch (BadHanyuPinyinOutputFormatCombination badHanyuPinyinOutputFormatCombination) {
+                    badHanyuPinyinOutputFormatCombination.printStackTrace();
+                }
+            }
+        }
+
+        StringBuilder pinyinStringBuilder = new StringBuilder();
+        if (first_letter.equals("prefix")) {
+            pinyinStringBuilder.append(firstLetters.toString());
+            if (this.padding_char.length() > 0) {
+                pinyinStringBuilder.append(this.padding_char); //TODO splitter
+            }
+            pinyinStringBuilder.append(stringBuilder.toString());
+        } else if (first_letter.equals("append")) {
+            pinyinStringBuilder.append(stringBuilder.toString());
+            if (this.padding_char.length() > 0) {
+                if (!stringBuilder.toString().endsWith(this.padding_char)) {
+                    pinyinStringBuilder.append(this.padding_char);
+                }
+            }
+            pinyinStringBuilder.append(firstLetters.toString());
+        } else if (first_letter.equals("none")) {
+            pinyinStringBuilder.append(stringBuilder.toString());
+        } else if (first_letter.equals("only")) {
+            pinyinStringBuilder.append(firstLetters.toString());
+        }
+        termAtt.setEmpty();
+        termAtt.resizeBuffer(pinyinStringBuilder.length());
+        termAtt.append(pinyinStringBuilder);
+        termAtt.setLength(pinyinStringBuilder.length());
+        return true;
+    }
+
+    public PinyinTokenFilter(TokenStream in, String padding_char, String first_letter) {
+        super(in);
+        this.padding_char = padding_char;
+        this.first_letter = first_letter;
+        format.setCaseType(HanyuPinyinCaseType.LOWERCASE);
+        format.setToneType(HanyuPinyinToneType.WITHOUT_TONE);
+        format.setVCharType(HanyuPinyinVCharType.WITH_V);
+    }
+}

--- a/src/main/java/org/elasticsearch/index/analysis/PinyinTokenFilterFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/PinyinTokenFilterFactory.java
@@ -1,0 +1,27 @@
+package org.elasticsearch.index.analysis;
+
+
+import org.apache.lucene.analysis.TokenStream;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.assistedinject.Assisted;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.settings.IndexSettings;
+
+
+/**
+ * @author kimchy (shay.banon)
+ */
+public class PinyinTokenFilterFactory extends AbstractTokenFilterFactory {
+    private String first_letter;
+    private String padding_char;
+    @Inject public PinyinTokenFilterFactory(Index index, @IndexSettings Settings indexSettings, @Assisted String name, @Assisted Settings settings) {
+        super(index, indexSettings, name, settings);
+        first_letter = settings.get("first_letter", "none");
+        padding_char = settings.get("padding_char", "");
+    }
+
+    @Override public TokenStream create(TokenStream tokenStream) {
+        return new PinyinTokenFilter(tokenStream,padding_char,first_letter);
+    }
+}


### PR DESCRIPTION
hi,medcl,
    I added a PinyinTokenFilter to work with Tokenizer(e.g. mmseg) for long text field which should first be tokenized before converted to pinyin.

if any problem with the code tell me and I'll fix it asap.
