### PR TITLE
在如下场景中:

### DIFF
--- a/src/main/java/org/elasticsearch/index/analysis/PinyinTokenFilter.java
+++ b/src/main/java/org/elasticsearch/index/analysis/PinyinTokenFilter.java
@@ -52,6 +52,7 @@ public class PinyinTokenFilter extends TokenFilter {
             char c = buffer[i];
             if (c < 128) {
                 stringBuilder.append(c);
+                firstLetters.append(c);
             } else {
                 try {
                     String[] strs = PinyinHelper.toHanyuPinyinStringArray(c, format);


### PR DESCRIPTION
(1) Tokenizer 使用 standard 或者 ik
(2) TokenFilter 使用 pinyin tokenfilter
(3) 选择 first_letter = "only"

当输入字符串为非汉字情况，如 "abc"，则分词输出结果为空字符串""，而不是原字符串 "abc"。

在 PinyinTokenFilter 中添加了修改，使得对非汉字获取拼音首字母时，会返回原字符，而不是空字符