### PR TITLE
修复startOffset must be non-negative, and endOffset must be >= startOffset, and offsets must not go backwards

### DIFF
--- a/src/main/java/org/elasticsearch/index/analysis/PinyinTokenizer.java
+++ b/src/main/java/org/elasticsearch/index/analysis/PinyinTokenizer.java
@@ -305,6 +305,7 @@ public class PinyinTokenizer extends Tokenizer {
         this.processedFirstLetter = false;
         this.processedFullPinyinLetter = false;
         this.processedOriginal = false;
+        this.processedSortCandidate = false;
         firstLetters.setLength(0);
         fullPinyinLetters.setLength(0);
         termsFilter.clear();


### PR DESCRIPTION
当将参数“ignore_pinyin_offset”设置为false后，并向pinyin分词字段批量写入数据，即会出现“startOffset must be non-negative, and endOffset must be >= startOffset, and offsets must not go backwards”异常。
测试校验发现为在reset()时，应该同样将this.processedSortCandidate = false，即可修复此问题。