### PR TITLE
开启ignore_pinyin_offset=false后，写入数组时offset没有递增报错bugfix

### DIFF
--- a/src/main/java/org/elasticsearch/index/analysis/PinyinTokenizer.java
+++ b/src/main/java/org/elasticsearch/index/analysis/PinyinTokenizer.java
@@ -293,6 +293,10 @@ public class PinyinTokenizer extends Tokenizer {
     @Override
     public final void end() throws IOException {
         super.end();
+        if(!config.ignorePinyinOffset){
+            ++lastOffset;
+            offsetAtt.setOffset(correctOffset(lastOffset), correctOffset(lastOffset));
+        }
     }
 
     @Override
@@ -312,6 +316,7 @@ public class PinyinTokenizer extends Tokenizer {
         candidate.clear();
         source = null;
         lastIncrementPosition = 0;
+        lastOffset = 0;
     }
 
 


### PR DESCRIPTION
开启ignore_pinyin_offset=false后，写入数组时offset没有递增报错lucene startOffset must be non-negative, and endOffset must be >= startOffset, and offsets must not go backwards。
通过把lastoffset传递给最后一个词项传递给下个数组元素解决。
