### PR TITLE
Use && to support short circuiting

### DIFF
--- a/src/main/java/org/elasticsearch/index/analysis/PinyinTokenFilter.java
+++ b/src/main/java/org/elasticsearch/index/analysis/PinyinTokenFilter.java
@@ -142,7 +142,7 @@ public class PinyinTokenFilter extends TokenFilter {
                     if (pinyin != null && pinyin.length() > 0) {
                         position++;
                         firstLetters.append(pinyin.charAt(0));
-                        if (config.keepSeparateFirstLetter & pinyin.length() > 1) {
+                        if (config.keepSeparateFirstLetter && pinyin.length() > 1) {
                             addCandidate(new TermItem(String.valueOf(pinyin.charAt(0)), i, i + 1, position));
                         }
                         if (config.keepFullPinyin) {


### PR DESCRIPTION
& and && have the same semantics when comparing boolean values. But && can perform a short-circuit logical AND operation, which makes more sense.