### PR TITLE
Upgrade Elasticsearch to 9.1.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,68 @@
+name: Test
+
+on:
+  push:
+    branches: ['*']
+  pull_request:
+    branches: ['*']
+
+jobs:
+  test-elasticsearch:
+    name: Test Elasticsearch=${{ matrix.elasticsearch }} JDK=${{ matrix.java }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [21, 24]
+        elasticsearch: ['9.0.0', '9.0.7', '9.1.0', '9.1.4']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Set Elasticsearch ${{ matrix.elasticsearch }} in POM
+        run: |
+          sed -i "s/<elasticsearch.version>.*<\/elasticsearch.version>/<elasticsearch.version>${{ matrix.elasticsearch }}<\/elasticsearch.version>/" elasticsearch/pom.xml
+          echo "Updated Elasticsearch version to ${{ matrix.elasticsearch }}"
+          grep -A 2 "<elasticsearch.version>" elasticsearch/pom.xml
+
+      - name: Build and test
+        run: mvn verify -B
+
+  test-opensearch:
+    name: Test OpenSearch=${{ matrix.opensearch }} JDK=${{ matrix.java }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [21, 24]
+        opensearch: ['2.0.1']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Set OpenSearch ${{ matrix.opensearch }} in POM
+        run: |
+          sed -i "s/<opensearch.version>.*<\/opensearch.version>/<opensearch.version>${{ matrix.opensearch }}<\/opensearch.version>/" opensearch/pom.xml
+          echo "Updated OpenSearch version to ${{ matrix.opensearch }}"
+          grep -A 2 "<opensearch.version>" opensearch/pom.xml
+
+      - name: Build and test
+        run: mvn verify -B

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ Pinyin Analysis for Elasticsearch and OpenSearch
 ==================================
 
 ![](./assets/banner.png)
+[![Test](https://github.com/infinilabs/analysis-pinyin/actions/workflows/test.yml/badge.svg)](https://github.com/infinilabs/analysis-pinyin/actions/workflows/test.yml)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE.txt)
 
 This Pinyin Analysis plugin facilitates the conversion between Chinese characters and Pinyin. It supports major versions of Elasticsearch and OpenSearch. Maintained and supported with ❤️ by [INFINI Labs](https://infinilabs.com).
 
@@ -49,7 +51,7 @@ or you can use the `plugin` cli to install the plugin like this:
 For Elasticsearch
 
 ```
-bin/elasticsearch-plugin install https://get.infini.cloud/elasticsearch/analysis-pinyin/8.4.1
+bin/elasticsearch-plugin install https://get.infini.cloud/elasticsearch/analysis-pinyin/9.1.4
 ```
 
 For OpenSearch

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -14,8 +14,8 @@
     <description>Pinyin Analysis for Elasticsearch</description>
     <packaging>jar</packaging>
     <properties>
-        <elasticsearch.version>9.0.0</elasticsearch.version>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <elasticsearch.version>9.1.4</elasticsearch.version>
+        <maven.compiler.target>21</maven.compiler.target>
         <!--<elasticsearch.assembly.descriptor>${basedir}/src/main/assemblies/plugin.xml</elasticsearch.assembly.descriptor>-->
         <plugin.name>analysis-pinyin</plugin.name>
         <elasticsearch.plugin.classname>com.infinilabs.elasticsearch.analysis.AnalysisPinyinPlugin</elasticsearch.plugin.classname>

--- a/opensearch/pom.xml
+++ b/opensearch/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <opensearch.version>2.0.1</opensearch.version>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.target>17</maven.compiler.target>
         <plugin.name>analysis-pinyin</plugin.name>
         <opensearch.plugin.classname>com.infinilabs.opensearch.analysis.AnalysisPinyinPlugin</opensearch.plugin.classname>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pinyin-core/pom.xml
+++ b/pinyin-core/pom.xml
@@ -13,8 +13,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -31,7 +31,7 @@
             <scope>provided</scope>
             <version>${lucene.version}</version>
         </dependency>
-        
+
         <dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
@@ -55,7 +55,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.5</version>
+			<version>2.19.0</version>
 			<scope>provided</scope>
 		</dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -16,10 +16,7 @@
     <inceptionYear>2012</inceptionYear>
 
     <properties>
-        <lucene.version>9.3.0</lucene.version>
-        
-        <opensearch.version>2.0.1</opensearch.version>
-        
+        <lucene.version>10.2.2</lucene.version>
         <tests.rest.load_packaged>false</tests.rest.load_packaged>
         <skip.unit.tests>true</skip.unit.tests>
         <gpg.keyname>4E899B30</gpg.keyname>
@@ -85,7 +82,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.17.1</version>
+            <version>2.19.0</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
This PR does the following:
- Upgrade to Elasticsearch 9.1.4
- Adds Github Actions test workflow which covers both Elasticsearch and Opensearch on various versions.
- Updates the `pom.xml` files with updated/corrected dependencies.
- Adds Test and License badges to the README file.