### PR TITLE
修复 PinyinTokenFilter 排序标志未重置的问题

### DIFF
--- a/pinyin-core/src/main/java/com/infinilabs/pinyin/analysis/PinyinTokenFilter.java
+++ b/pinyin-core/src/main/java/com/infinilabs/pinyin/analysis/PinyinTokenFilter.java
@@ -315,6 +315,7 @@ public class PinyinTokenFilter extends TokenFilter {
         this.processedFirstLetter = false;
         this.processedFullPinyinLetter = false;
         this.processedOriginal = false;
+        this.processedSortCandidate = false;
         firstLetters.setLength(0);
         fullPinyinLetters.setLength(0);
         source = null;

--- a/pinyin-core/src/test/java/com/infinilabs/pinyin/analysis/PinyinAnalysisTest.java
+++ b/pinyin-core/src/test/java/com/infinilabs/pinyin/analysis/PinyinAnalysisTest.java
@@ -223,9 +223,9 @@ public class PinyinAnalysisTest {
         Assert.assertEquals("hua", pinyin.get(3));
         Assert.assertEquals("m", pinyin.get(4));
         Assert.assertEquals("ming", pinyin.get(5));
-        Assert.assertEquals("z", pinyin.get(6));
-        Assert.assertEquals("zi", pinyin.get(7));
-        Assert.assertEquals("mz", pinyin.get(8));
+        Assert.assertEquals("mz", pinyin.get(6));
+        Assert.assertEquals("z", pinyin.get(7));
+        Assert.assertEquals("zi", pinyin.get(8));
 
 
         config = new PinyinConfig();


### PR DESCRIPTION
## 修复 PinyinTokenFilter 排序标志未重置的问题

### 问题
使用 `keyword + pinyin filter` 组合时(包含pinyin filter即可)，第一次分词结果与之后执行的结果顺序不一致。
- 对 [GT40] 分词
```
  "ignore_pinyin_offset": "true",
  "keep_first_letter": "false",
  "keep_none_chinese_in_joined_full_pinyin": "false",
  "keep_none_chinese_together": "true",
  "keep_original": "true",
  "limit_first_letter_length": 16,
  "lowercase": "true",
  "remove_duplicated_term": "false",
  "type": "pinyin"
```
- 第一次检索
``` 
{
  "tokens": [
    {
      "token": "g",
      "start_offset": 0,
      "end_offset": 4,
      "type": "word",
      "position": 0
    },
    {
      "token": "gt40",
      "start_offset": 0,
      "end_offset": 4,
      "type": "word",
      "position": 0
    },
    {
      "token": "t",
      "start_offset": 0,
      "end_offset": 4,
      "type": "word",
      "position": 1
    },
    {
      "token": "40",
      "start_offset": 0,
      "end_offset": 4,
      "type": "word",
      "position": 2
    }
  ]
}
```

- 之后的测试

```
{
  "tokens": [
    {
      "token": "g",
      "start_offset": 0,
      "end_offset": 4,
      "type": "word",
      "position": 0
    },
    {
      "token": "t",
      "start_offset": 0,
      "end_offset": 4,
      "type": "word",
      "position": 1
    },
    {
      "token": "40",
      "start_offset": 0,
      "end_offset": 4,
      "type": "word",
      "position": 2
    },
    {
      "token": "gt40",
      "start_offset": 0,
      "end_offset": 4,
      "type": "word",
      "position": 2
    }
  ]
}
```

### 原因
`PinyinTokenFilter.resetVariable()` 中没有重置 `processedSortCandidate`。

### 修复
在 `resetVariable()` 中添加 `this.processedSortCandidate = false;`