### PR TITLE
fix:  loss of the initial character of the single-character pinyin in keep_separate_first_letter #245

### DIFF
--- a/opensearch/src/main/resources/plugin-descriptor.properties
+++ b/opensearch/src/main/resources/plugin-descriptor.properties
@@ -58,4 +58,4 @@ custom.foldername=
 extended.plugins=
 #
 # 'has.native.controller': whether or not the plugin has a native controller
-has.native.controller=
+has.native.controller=false

--- a/pinyin-core/src/main/java/com/infinilabs/pinyin/analysis/PinyinTokenFilter.java
+++ b/pinyin-core/src/main/java/com/infinilabs/pinyin/analysis/PinyinTokenFilter.java
@@ -140,7 +140,7 @@ public class PinyinTokenFilter extends TokenFilter {
                     if (pinyin != null && pinyin.length() > 0) {
                         position++;
                         firstLetters.append(pinyin.charAt(0));
-                        if (config.keepSeparateFirstLetter && pinyin.length() > 1) {
+                        if (config.keepSeparateFirstLetter && pinyin.length() >= 1) {
                             addCandidate(new TermItem(String.valueOf(pinyin.charAt(0)), i, i + 1, position));
                         }
                         if (config.keepFullPinyin) {

--- a/pinyin-core/src/main/java/com/infinilabs/pinyin/analysis/PinyinTokenizer.java
+++ b/pinyin-core/src/main/java/com/infinilabs/pinyin/analysis/PinyinTokenizer.java
@@ -197,7 +197,7 @@ public class PinyinTokenizer extends Tokenizer {
                         String chinese = chineseList.get(i);
                         if (pinyin != null && pinyin.length() > 0) {
                             firstLetters.append(pinyin.charAt(0));
-                            if (config.keepSeparateFirstLetter & pinyin.length() > 1) {
+                            if (config.keepSeparateFirstLetter & pinyin.length() >= 1) {
                                 position++;
                                 incrPosition = true;
                                 addCandidate(new TermItem(String.valueOf(pinyin.charAt(0)), i, i + 1, position));

--- a/pinyin-core/src/test/java/com/infinilabs/pinyin/analysis/PinyinAnalysisTest.java
+++ b/pinyin-core/src/test/java/com/infinilabs/pinyin/analysis/PinyinAnalysisTest.java
@@ -1525,4 +1525,29 @@ public class PinyinAnalysisTest {
 
 
     }
+
+    @Test
+    public void testSeparateFirstLetterWithSingleCharPinyin() throws IOException {
+        // 测试单字符拼音（a, e, o）的首字母不丢失
+        // "小阿哦明" 的拼音: xiao, a, o, ming
+        // 期望 keep_separate_first_letter 输出: x, a, o, m
+        String[] s = new String[]{"小阿哦明"};
+
+        PinyinConfig config = new PinyinConfig();
+        config.keepFirstLetter = false;
+        config.keepSeparateFirstLetter = true;
+        config.keepFullPinyin = false;
+        config.keepJoinedFullPinyin = false;
+        config.keepOriginal = false;
+        config.ignorePinyinOffset = false;
+
+        HashMap<String, ArrayList<TermItem>> result = getStringArrayListHashMap(s, config);
+
+        ArrayList<TermItem> re = result.get("小阿哦明");
+        Assert.assertEquals(4, re.size());
+        Assert.assertEquals("x", re.get(0).term);
+        Assert.assertEquals("a", re.get(1).term);
+        Assert.assertEquals("o", re.get(2).term);
+        Assert.assertEquals("m", re.get(3).term);
+    }
 }


### PR DESCRIPTION
# 1.  fix the bug in #245 
## Summary

  Fix single-character pinyin first letter tokens being dropped when `keep_separate_first_letter=true`.

  ## Root Cause

  `PinyinTokenizer` and `PinyinTokenFilter` used `pinyin.length() > 1` to filter candidates, which excluded characters whose pinyin is a single vowel (e.g. "阿"→a, "鹅"→e, "哦"→o).

  ```java
  // Before: single-char pinyin filtered out
  if (config.keepSeparateFirstLetter & pinyin.length() > 1) {

  // After: single-char pinyin included
  if (config.keepSeparateFirstLetter & pinyin.length() >= 1) {

  Changes

  - PinyinTokenizer.java: pinyin.length() > 1 → >= 1
  - PinyinTokenFilter.java: pinyin.length() > 1 → >= 1
  - PinyinAnalysisTest.java: add testSeparateFirstLetterWithSingleCharPinyin test case
  - plugin-descriptor.properties: set has.native.controller=false (OpenSearch 3.x compatibility)

  Verification

  Verified on ES 9.4.0 and OpenSearch 3.6.0:

  ┌──────────┬─────────┬─────────────────────┐
  │  Input   │ Before  │        After        │
  ├──────────┼─────────┼─────────────────────┤
  │ 小阿哦明 │ x, m    │ x, a, e, m          │
  ├──────────┼─────────┼─────────────────────┤
  │ 阿莫西林 │ m, x, l │ a, m, x, l          │
  ├──────────┼─────────┼─────────────────────┤
  │ 鹅毛     │ m       │ e, m                │
  ├──────────┼─────────┼─────────────────────┤
  │ 刘德华   │ l, d, h │ l, d, h (unchanged) │
  └──────────┴─────────┴─────────────────────┘
  
  # 2. Fix OpenSearch 3.x plugin installation failure
      - plugin-descriptor.properties: set has.native.controller=false
    - OpenSearch 3.x requires this field to be true or false, an empty value causes plugin installation to fail. ES is not affected.